### PR TITLE
add ssh config for infrastructure customizations

### DIFF
--- a/.ssh/config
+++ b/.ssh/config
@@ -1,0 +1,3 @@
+Host github.com
+  Hostname ssh.github.com
+  Port 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,5 @@ FROM mesosphere/jenkins-dind:0.5.0-alpine
 
 RUN apk add --upgrade py-pip make
 RUN pip install --upgrade awscli docker-compose
+
+ADD .ssh/config /root/.ssh/config


### PR DESCRIPTION
We don't allow port 22 - so redirect to `ssh.github.com` on 443 instead.